### PR TITLE
Generate read/write functions for structs

### DIFF
--- a/lexer.py
+++ b/lexer.py
@@ -238,6 +238,10 @@ def tokenize_line(line: str, line_num: int, filename: str) -> List[Token]:
     return tokens
 
 
+def tokenize_string(string: str) -> List[Token]:
+    return tokenize_line(string, 0, "")
+
+
 def tokenize(filepath: str) -> List[Token]:
     with open(filepath) as file:
         file_lines = file.readlines()

--- a/prelude/prelude.tlp
+++ b/prelude/prelude.tlp
@@ -6,7 +6,7 @@ fn @int ptr -> int ptr do
     cast(int) SizeOf(int) - cast(ptr) dup @64 cast(int) swap
 end
 
-fn !bool int ptr -> ptr do 
+fn !bool bool ptr -> ptr do 
     dup push !64 pop cast(int) SizeOf(bool) + cast(ptr)
 end
 
@@ -20,4 +20,9 @@ end
 
 fn @ptr ptr -> ptr ptr do
     cast(int) SizeOf(ptr) - cast(ptr) dup @64 cast(ptr) swap
+end
+
+struct Str
+    int
+    ptr
 end

--- a/tests/functional_tests/read_write.tlp
+++ b/tests/functional_tests/read_write.tlp
@@ -1,0 +1,8 @@
+use "std.tlp"
+reserve two_strings SizeOf(Str) 2 * end
+
+"Hello World!\n" two_strings !Str push
+"Hi again!\n" pop !Str
+
+@Str push puts pop
+@Str drop puts

--- a/tests/functional_tests/read_write.txt
+++ b/tests/functional_tests/read_write.txt
@@ -1,0 +1,15 @@
+args: ['python3', 'tulip.py', './tests/functional_tests/read_write.tlp']
+-------- stdout ----------
+--------------------------
+-------- stderr ----------
+--------------------------
+exit code: 0
+##########################
+args: ['./output']
+-------- stdout ----------
+Hi again!
+Hello World!
+--------------------------
+-------- stderr ----------
+--------------------------
+exit code: 0


### PR DESCRIPTION
Str type is now defined in the prelude. 

Added `tokenize_string` to `lexer.py` to make it easier to generate tokens during compilation. Cleaned up the code generation for the struct element accessing functions. Structs now also generate `!Struct` and `@Struct` functions which do the following:

| Function | Signature | Description |
|-------------|---------------|----------------|
| !Struct | `Struct ptr -> ptr` | Writes a pointer to memory and returns a pointer to just past the written struct. |
| @Struct | `ptr -> Struct ptr` | Reads a <name> from a pointer one past the struct to be read and returns the pointer set to the start of the Struct | 